### PR TITLE
no metadata is applied to data1

### DIFF
--- a/JavaScript/4-array.js
+++ b/JavaScript/4-array.js
@@ -66,7 +66,7 @@ function buildGetter(proto, fieldName, fieldType, fieldIndex) {
     });
   }
 }
-
+data1.forEach((person) => Object.setPrototypeOf(person, Person.prototype));
 data2.forEach((person) => Object.setPrototypeOf(person, Person.prototype));
 //data2.forEach(person => person.__proto__ = Person.prototype);
 


### PR DESCRIPTION
Because no metadata is applied to data1,
filter data1.filter(query)  returns [ ].
And, as result, comparison of tests by filtration is not correct...