### PR TITLE
Improve examples

### DIFF
--- a/JavaScript/2-benchmark.js
+++ b/JavaScript/2-benchmark.js
@@ -35,7 +35,7 @@ const opt = fn => {
     if (n === 0) return;
     if (Math.pow(2, n) & optStatus) results.push(name);
   });
-  return results.length ? results.join(', ') : 'no preopt,';
+  return results.length ? results.join(', ') : 'no preopt';
 }
 
 const optimize = fn => %OptimizeFunctionOnNextCall(fn);
@@ -64,9 +64,8 @@ benchmark.do = (count, tests) => {
     const diff = end - begin;
     const name = rpad(fn.name, '.', 22);
     const iterations = result.length - PRE_COUNT;
-    const log = [
-      name, diff, optBefore, optAfter, optAfterHeat, optAfterLoop
-    ];
+    const opts = [optBefore, optAfter, optAfterHeat, optAfterLoop];
+    const log = [name, diff, opts.join(' -> ')];
     console.log(log.join(' '));
     return { name, time: diff };
   });

--- a/JavaScript/3-instantiation.js
+++ b/JavaScript/3-instantiation.js
@@ -6,7 +6,8 @@ const makeClosure = (hello, size, flag) => () => (
   { hello, size, flag }
 );
 
-const closureInstance = () => makeClosure('world', 100500, true);
+const closureInstance = makeClosure('world', 100500, true);
+const invokeClosure = () => closureInstance();
 
 const defineArray = () => ['world', 100500, true];
 
@@ -68,7 +69,7 @@ const callFactory = () => itemFactory('world', 100500, true);
 
 benchmark.do(1000000, [
   callFactory,
-  closureInstance,
+  invokeClosure,
   defineObject,
   defineArray,
   defineArrayOfString,

--- a/JavaScript/4-array.js
+++ b/JavaScript/4-array.js
@@ -4,6 +4,15 @@ const benchmark = require('./2-benchmark.js');
 
 // Define Data Source
 
+function AgeComputable() {}
+Object.defineProperty(AgeComputable.prototype, 'age', {
+  get() {
+    const difference = new Date() - this.birth;
+    return Math.floor(difference / 31536000000);
+  },
+  enumerable: true,
+});
+
 const data1 = [
   { name: 'Marcus Aurelius',
     birth: new Date('212-04-26'),
@@ -20,7 +29,7 @@ const data1 = [
   { name: 'Rene Descartes',
     birth: new Date('1596-03-31'),
     city: 'La Haye en Touraine' },
-];
+].map((person) => Object.setPrototypeOf(person, AgeComputable.prototype));
 
 const data2 = [
   ['Marcus Aurelius', '212-04-26', 'Rome'],
@@ -80,11 +89,11 @@ const query = (person) => (
 
 // Execute tests
 
+const filterObjects = () => data1.filter(query);
+
+const filterArrays = () => data2.filter(query);
+
 benchmark.do(1000000, [
-  function filterObjects() {
-    data1.filter(query);
-  },
-  function filterArrays() {
-    data2.filter(query);
-  }
+  filterObjects,
+  filterArrays
 ]);


### PR DESCRIPTION
The final log in `2-benchmark` has been changed.
Comma only appeared in cases where there were a few optimisations in a single `opt` call:
`closureInstance....... 330061782 no preopt, interp interp opt, turbofan`

An arrow has been added to distinct optimization steps in the final log:
`closureInstance....... 213392979 no preopt -> interp -> interp -> opt, turbofan`


`closureInstance` in `3-instantiation` has been fixed. Previously it returned a function instead of an object instance.


In `4-array` `data1` elements didn't have `age` property, so the query filter always failed.
This issue has already been addressed in https://github.com/HowProgrammingWorks/Benchmark/pull/15, but I believe it is better to create a separate prototype for objects rather than using the same one as for arrays.